### PR TITLE
Enable tap-to-click by default

### DIFF
--- a/include/wm/wm_config.h
+++ b/include/wm/wm_config.h
@@ -22,12 +22,15 @@ struct wm_config {
     const char* xcursor_theme;
     int xcursor_size;
 
-    int focus_follows_mouse;
-    int constrain_popups_to_toplevel;
+    bool tap_to_click;
+    bool natural_scroll;
 
-    int encourage_csd;
+    bool focus_follows_mouse;
+    bool constrain_popups_to_toplevel;
 
-    int debug_f1;
+    bool encourage_csd;
+
+    bool debug_f1;
 };
 
 void wm_config_init_default(struct wm_config* config);

--- a/include/wm/wm_config.h
+++ b/include/wm/wm_config.h
@@ -22,15 +22,12 @@ struct wm_config {
     const char* xcursor_theme;
     int xcursor_size;
 
-    bool tap_to_click;
-    bool natural_scroll;
+    int focus_follows_mouse;
+    int constrain_popups_to_toplevel;
 
-    bool focus_follows_mouse;
-    bool constrain_popups_to_toplevel;
+    int encourage_csd;
 
-    bool encourage_csd;
-
-    bool debug_f1;
+    int debug_f1;
 };
 
 void wm_config_init_default(struct wm_config* config);

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,6 @@
 #include "wm/wm_config.h"
 #include "wm/wm.h"
 
-
 int main(int argc, char** argv){
     struct wm_config config;
     wm_config_init_default(&config);

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "wm/wm_config.h"
 #include "wm/wm.h"
 
+
 int main(int argc, char** argv){
     struct wm_config config;
     wm_config_init_default(&config);

--- a/src/py/_pywmmodule.c
+++ b/src/py/_pywmmodule.c
@@ -93,9 +93,6 @@ static PyObject* _pywm_run(PyObject* self, PyObject* args, PyObject* kwargs){
         o = PyDict_GetItemString(kwargs, "output_height"); if(o){ conf.output_height = PyLong_AsLong(o); }
         o = PyDict_GetItemString(kwargs, "output_mHz"); if(o){ conf.output_mHz= PyLong_AsLong(o); }
 
-        o = PyDict_GetItemString(kwargs, "tap_to_click"); if(o){ conf.tap_to_click = o == Py_True; }
-        o = PyDict_GetItemString(kwargs, "natural_scroll"); if(o){ conf.natural_scroll = o == Py_True; }
-
         o = PyDict_GetItemString(kwargs, "focus_follows_mouse"); if(o){ conf.focus_follows_mouse = o == Py_True; }
         o = PyDict_GetItemString(kwargs, "constrain_popups_to_toplevel"); if(o){ conf.constrain_popups_to_toplevel = o == Py_True; }
         o = PyDict_GetItemString(kwargs, "encourage_csd"); if(o){ conf.encourage_csd = o == Py_True; }

--- a/src/py/_pywmmodule.c
+++ b/src/py/_pywmmodule.c
@@ -93,6 +93,9 @@ static PyObject* _pywm_run(PyObject* self, PyObject* args, PyObject* kwargs){
         o = PyDict_GetItemString(kwargs, "output_height"); if(o){ conf.output_height = PyLong_AsLong(o); }
         o = PyDict_GetItemString(kwargs, "output_mHz"); if(o){ conf.output_mHz= PyLong_AsLong(o); }
 
+        o = PyDict_GetItemString(kwargs, "tap_to_click"); if(o){ conf.tap_to_click = o == Py_True; }
+        o = PyDict_GetItemString(kwargs, "natural_scroll"); if(o){ conf.natural_scroll = o == Py_True; }
+
         o = PyDict_GetItemString(kwargs, "focus_follows_mouse"); if(o){ conf.focus_follows_mouse = o == Py_True; }
         o = PyDict_GetItemString(kwargs, "constrain_popups_to_toplevel"); if(o){ conf.constrain_popups_to_toplevel = o == Py_True; }
         o = PyDict_GetItemString(kwargs, "encourage_csd"); if(o){ conf.encourage_csd = o == Py_True; }

--- a/src/wm/wm_config.c
+++ b/src/wm/wm_config.c
@@ -20,6 +20,9 @@ void wm_config_init_default(struct wm_config* config){
     config->xcursor_theme = NULL;
     config->xcursor_size = 24;
 
+    config->natural_scroll = true;
+    config->tap_to_click = true;
+
     config->focus_follows_mouse = true;
     config->constrain_popups_to_toplevel = false;
 

--- a/src/wm/wm_config.c
+++ b/src/wm/wm_config.c
@@ -20,9 +20,6 @@ void wm_config_init_default(struct wm_config* config){
     config->xcursor_theme = NULL;
     config->xcursor_size = 24;
 
-    config->natural_scroll = true;
-    config->tap_to_click = true;
-
     config->focus_follows_mouse = true;
     config->constrain_popups_to_toplevel = false;
 

--- a/src/wm/wm_pointer.c
+++ b/src/wm/wm_pointer.c
@@ -30,6 +30,7 @@ void wm_pointer_init(struct wm_pointer* pointer, struct wm_seat* seat, struct wl
         if(libinput_device_config_scroll_has_natural_scroll(device)){
             libinput_device_config_scroll_set_natural_scroll_enabled(device, true);
         }
+        libinput_device_config_tap_set_enabled(device, true);
     }
 
     pointer->destroy.notify = handle_destroy;

--- a/src/wm/wm_pointer.c
+++ b/src/wm/wm_pointer.c
@@ -6,6 +6,9 @@
 #include <wlr/backend/libinput.h>
 #include <libinput.h>
 #include <assert.h>
+#include "wm/wm.h"
+#include "wm/wm_server.h"
+#include "wm/wm_config.h"
 #include "wm/wm_pointer.h"
 #include "wm/wm_seat.h"
 
@@ -24,13 +27,15 @@ void wm_pointer_init(struct wm_pointer* pointer, struct wm_seat* seat, struct wl
     pointer->wm_seat = seat;
     pointer->wlr_input_device = input_device;
 
+    struct wm_config* config = get_wm()->server->wm_config;
+
     /* Natural scrolling is the only thing that makes sense */
     if(wlr_input_device_is_libinput(pointer->wlr_input_device)){
         struct libinput_device* device = wlr_libinput_get_device_handle(pointer->wlr_input_device);
         if(libinput_device_config_scroll_has_natural_scroll(device)){
-            libinput_device_config_scroll_set_natural_scroll_enabled(device, true);
+            libinput_device_config_scroll_set_natural_scroll_enabled(device, config->natural_scroll);
         }
-        libinput_device_config_tap_set_enabled(device, true);
+        libinput_device_config_tap_set_enabled(device, config->tap_to_click);
     }
 
     pointer->destroy.notify = handle_destroy;

--- a/src/wm/wm_pointer.c
+++ b/src/wm/wm_pointer.c
@@ -6,9 +6,6 @@
 #include <wlr/backend/libinput.h>
 #include <libinput.h>
 #include <assert.h>
-#include "wm/wm.h"
-#include "wm/wm_server.h"
-#include "wm/wm_config.h"
 #include "wm/wm_pointer.h"
 #include "wm/wm_seat.h"
 
@@ -27,15 +24,13 @@ void wm_pointer_init(struct wm_pointer* pointer, struct wm_seat* seat, struct wl
     pointer->wm_seat = seat;
     pointer->wlr_input_device = input_device;
 
-    struct wm_config* config = get_wm()->server->wm_config;
-
     /* Natural scrolling is the only thing that makes sense */
     if(wlr_input_device_is_libinput(pointer->wlr_input_device)){
         struct libinput_device* device = wlr_libinput_get_device_handle(pointer->wlr_input_device);
         if(libinput_device_config_scroll_has_natural_scroll(device)){
-            libinput_device_config_scroll_set_natural_scroll_enabled(device, config->natural_scroll);
+            libinput_device_config_scroll_set_natural_scroll_enabled(device, true);
         }
-        libinput_device_config_tap_set_enabled(device, config->tap_to_click);
+        libinput_device_config_tap_set_enabled(device, true);
     }
 
     pointer->destroy.notify = handle_destroy;


### PR DESCRIPTION
Libinput only enables tap-to-click for touch devices that don't have physical buttons (for dubious reasons imo).

On an unrelated note libinput requires wayland compositors to manage these sorts of configurations so it would be a good idea to expose some [libinput device config api](https://wayland.freedesktop.org/libinput/doc/latest/api/group__config.html) endpoints somewhere, potentially with device-specific configuration like in sway.