### PR TITLE
Float fewer xwayland windows v2

### DIFF
--- a/include/wm/wm_server.h
+++ b/include/wm/wm_server.h
@@ -1,6 +1,7 @@
 #ifndef WM_SERVER_H
 #define WM_SERVER_H
 
+#include "xwayland/xwm.h"
 #include <time.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
@@ -12,12 +13,29 @@
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 
+#ifdef WM_HAS_XWAYLAND
+#include <xcb/xproto.h>
+#endif
+
 struct wm_config;
 struct wm_seat;
 struct wm_layout;
 struct wm_renderer;
 struct wm_output;
 struct wm_idle_inhibit;
+
+#ifdef WM_HAS_XWAYLAND
+// wlroots defines an enum with some of the same names so strip the prefix
+enum wm_atom_name {
+	WINDOW_TYPE_NORMAL,
+	WINDOW_TYPE_DIALOG,
+	WINDOW_TYPE_UTILITY,
+	WINDOW_TYPE_TOOLBAR,
+	WINDOW_TYPE_MENU,
+    WINDOW_TYPE_DOCK,
+    WM_ATOM_LAST
+};
+#endif
 
 struct wm_server{
     struct wm_config* wm_config;
@@ -38,6 +56,7 @@ struct wm_server{
     struct wlr_xdg_decoration_manager_v1* wlr_xdg_decoration_manager;
 #ifdef WM_HAS_XWAYLAND
     struct wlr_xwayland* wlr_xwayland;
+    xcb_atom_t xcb_atoms[WM_ATOM_LAST];
 #endif
     struct wlr_xcursor_manager* wlr_xcursor_manager;
     struct wlr_virtual_keyboard_manager_v1* wlr_virtual_keyboard_manager;

--- a/src/wm/wm_view_xwayland.c
+++ b/src/wm/wm_view_xwayland.c
@@ -23,7 +23,6 @@ static void try_to_find_parent(struct wm_view_xwayland* view){
     
     if(view->wlr_xwayland_surface->parent){
         unsigned int parent_id = view->wlr_xwayland_surface->parent->window_id;
-        wlr_log(WLR_DEBUG, "Trying to find parent using window id %u", parent_id);
         struct wm_content* it;
         wl_list_for_each(it, &view->super.super.wm_server->wm_contents, link){
             if(it->vtable != view->super.super.vtable) continue;


### PR DESCRIPTION
Assuming that two XWayland windows with the same process ID are parent and child can also cause new instances of the same application to be treated like child windows when they really represent new applications. For example, clicking the New Window option in VSCode creates a floating window instead of tiling a new instance of the application.

This pull request updates pywm to only match up PIDs for certain window types that are expected to be child windows.
